### PR TITLE
Fix missing `inputs` in the esbuild reports

### DIFF
--- a/.changeset/perfect-peaches-tease.md
+++ b/.changeset/perfect-peaches-tease.md
@@ -1,0 +1,6 @@
+---
+"sonda": patch
+"unplugin-sourcemaps": patch
+---
+
+Configure npm package provenance

--- a/.changeset/witty-humans-pump.md
+++ b/.changeset/witty-humans-pump.md
@@ -1,0 +1,5 @@
+---
+"sonda": patch
+---
+
+Fix missing "inputs" in the report created by the esbuild plugin.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,3 +44,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/packages/sonda/package.json
+++ b/packages/sonda/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@ampproject/remapping": "^2.3.0",
+    "@jridgewell/sourcemap-codec": "^1.5.0",
     "open": "^10.1.0"
   },
   "devDependencies": {

--- a/packages/sonda/package.json
+++ b/packages/sonda/package.json
@@ -20,6 +20,9 @@
     "url": "git+https://github.com/filipsobol/sonda.git",
     "directory": "packages/sonda"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/sonda/package.json
+++ b/packages/sonda/package.json
@@ -20,9 +20,6 @@
     "url": "git+https://github.com/filipsobol/sonda.git",
     "directory": "packages/sonda"
   },
-  "publishConfig": {
-    "provenance": true
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/sonda/src/bundlers/esbuild.ts
+++ b/packages/sonda/src/bundlers/esbuild.ts
@@ -1,7 +1,9 @@
+import { resolve } from 'path';
 import { normalizeOptions } from '../utils';
 import { generateReportFromAssets } from '../report/generate';
 import type { Plugin } from 'esbuild';
 import type { Options, JsonReport } from '../types';
+import { addSourcesToInputs } from '../sourcemap/map';
 
 export function SondaEsbuildPlugin( options?: Partial<Options> ): Plugin {
 	return {
@@ -14,16 +16,32 @@ export function SondaEsbuildPlugin( options?: Partial<Options> ): Plugin {
 					return console.error( 'Metafile is required for SondaEsbuildPlugin to work.' );
 				}
 
+				const cwd = process.cwd();
+				const normalizedOptions = normalizeOptions( options );
+
+				// Esbuild already reads the existing source maps, so there's no need to do it again
+				normalizedOptions.detailed = false;
+
 				const inputs = Object
 					.entries( result.metafile.inputs )
 					.reduce( ( acc, [ path, data ] ) => {
-						
 						acc[ path ] = {
 							bytes: data.bytes,
 							format: data.format ?? 'unknown',
 							imports: data.imports.map( data => data.path ),
 							belongsTo: null,
 						};
+
+						/**
+						 * Because esbuild already reads the existing source maps, there may be
+						 * cases where some report "outputs" include "inputs" don't exist in the
+						 * main "inputs" object. To avoid this, we parse each esbuild input and
+						 * add its sources to the "inputs" object.
+						 */
+						addSourcesToInputs(
+							resolve( cwd, path ),
+							acc
+						);
 
 						return acc;
 					}, {} as JsonReport[ 'inputs' ] );

--- a/packages/sonda/src/report.ts
+++ b/packages/sonda/src/report.ts
@@ -2,6 +2,7 @@ import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
 import { loadCodeAndMap } from 'load-source-map';
+import { decode } from '@jridgewell/sourcemap-codec';
 import { mapSourceMap } from './sourcemap/map.js';
 import { getBytesPerSource, getSizes } from './sourcemap/bytes.js';
 import type {
@@ -62,7 +63,9 @@ function processAsset(
   }
 
   const { code, map } = maybeCodeMap;
-  const mapped = mapSourceMap( map, dirname( asset ), inputs, options );
+  const mapped = options.detailed
+    ? mapSourceMap( map, dirname( asset ), inputs )
+    : { ...map, mappings: decode( map.mappings ) };
 
   mapped.sources = mapped.sources.map( source => normalizePath( source! ) );
 

--- a/packages/unplugin-sourcemaps/package.json
+++ b/packages/unplugin-sourcemaps/package.json
@@ -18,6 +18,9 @@
     "url": "git+https://github.com/filipsobol/sonda.git",
     "directory": "packages/unplugin-sourcemaps"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/unplugin-sourcemaps/package.json
+++ b/packages/unplugin-sourcemaps/package.json
@@ -18,9 +18,6 @@
     "url": "git+https://github.com/filipsobol/sonda.git",
     "directory": "packages/unplugin-sourcemaps"
   },
-  "publishConfig": {
-    "provenance": true
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@ampproject/remapping':
         specifier: ^2.3.0
         version: 2.3.0
+      '@jridgewell/sourcemap-codec':
+        specifier: ^1.5.0
+        version: 1.5.0
       open:
         specifier: ^10.1.0
         version: 10.1.0
@@ -103,7 +106,7 @@ importers:
         version: 4.24.0
       webpack:
         specifier: ^5.89.0
-        version: 5.94.0(esbuild@0.23.1)
+        version: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.1)
 
   packages/unplugin-sourcemaps:
     dependencies:
@@ -6553,6 +6556,18 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  terser-webpack-plugin@5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.1)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.33.0
+      webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.1)
+    optionalDependencies:
+      '@swc/core': 1.7.26(@swc/helpers@0.5.13)
+      esbuild: 0.23.1
+
   terser-webpack-plugin@5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -6563,17 +6578,6 @@ snapshots:
       webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
-
-  terser-webpack-plugin@5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.33.0
-      webpack: 5.94.0(esbuild@0.23.1)
-    optionalDependencies:
-      esbuild: 0.23.1
 
   terser@5.33.0:
     dependencies:
@@ -6754,6 +6758,36 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
+  webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.1):
+    dependencies:
+      '@types/estree': 1.0.6
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.12.1
+      acorn-import-attributes: 1.9.5(acorn@8.12.1)
+      browserslist: 4.23.3
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.5.4
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.1)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.1))
+      watchpack: 2.4.2
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
   webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(webpack-cli@5.1.4):
     dependencies:
       '@types/estree': 1.0.6
@@ -6781,36 +6815,6 @@ snapshots:
       webpack-sources: 3.2.3
     optionalDependencies:
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.94.0)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.94.0(esbuild@0.23.1):
-    dependencies:
-      '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.12.1
-      acorn-import-attributes: 1.9.5(acorn@8.12.1)
-      browserslist: 4.23.3
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1))
-      watchpack: 2.4.2
-      webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild


### PR DESCRIPTION
Esbuild already reads the existing source maps, so it doesn't give Sonda a chance to build the relationship tree between bundles used in the build process and “sources” from theirs source maps. This can result in some “output.inputs” being missing from the “inputs”.

To prevent this, we need to read source maps of every input and update the “inputs” object.

This fixes missing `File format` and `Original file size`.