### PR TITLE
fix: add `mjs` and `cjs` as accepted asset extensions

### DIFF
--- a/packages/sonda/src/report.ts
+++ b/packages/sonda/src/report.ts
@@ -21,7 +21,7 @@ export function generateJsonReport(
   inputs: Record<string, ReportInput>,
   options: Options
 ): JsonReport {
-  const acceptedExtensions = [ '.js', '.css' ];
+  const acceptedExtensions = [ '.js', '.mjs', '.cjs', '.css' ];
 
   const outputs = assets
     .filter( asset => acceptedExtensions.includes( extname( asset ) ) )


### PR DESCRIPTION
This PR adds `.mjs` and `.cjs` to the list of `acceptedExtensions`.

This is needed by https://github.com/vuejs/language-tools/pull/4998. Currently, because the assets are `.cjs` files, Sonda doesn't analyze them and reports "No data to display".
