### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: Build packages
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: Build packages


### PR DESCRIPTION
Potential fix for [https://github.com/filipsobol/sonda/security/code-scanning/2](https://github.com/filipsobol/sonda/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow file. This block will explicitly define the permissions required for the workflow, limiting access to the minimum necessary. Based on the workflow's actions, the `contents: read` permission is sufficient for most steps, while the `pull-requests: write` permission is required for the "Release preview" step that publishes updates to pull requests.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. If specific jobs require different permissions, we can define job-specific permissions later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
