### PR TITLE
fix: update `@ampproject/remapping` to `@jridgewell/remapping`

### DIFF
--- a/docs/features/dependency-tree.md
+++ b/docs/features/dependency-tree.md
@@ -16,7 +16,7 @@ In this example, the selected file appears in the bundle because:
 1. The file `src/index.ts` is the entry point for the asset,
 2. it imports `./report/report.js`,
 3. it imports `./processors/outputs.js`,
-4. it imports `@ampproject/remapping`,
+4. it imports `@jridgewell/remapping`,
 5. it imports `@jridgewell/trace-mapping`,
 6. it imports `@jridgewell/sourcemap-codec`,
 7. its source map references `[...]/src/sourcemap-codec.ts` which is the inspected file.

--- a/docs/features/json-report.md
+++ b/docs/features/json-report.md
@@ -43,9 +43,9 @@ Before we dive into the details of each field, here is the top-level structure o
   ],
   "dependencies": [
     {
-      "name": "@ampproject/remapping",
+      "name": "@jridgewell/remapping",
       "paths": [
-        "node_modules/@ampproject/remapping"
+        "node_modules/@amppjridgewellroject/remapping"
       ]
     }
   ],

--- a/packages/sonda/package.json
+++ b/packages/sonda/package.json
@@ -66,7 +66,7 @@
     "dev": "rolldown -w -c"
   },
   "dependencies": {
-    "@ampproject/remapping": "^2.3.0",
+    "@jridgewell/remapping": "^2.3.0",
     "open": "^10.2.0"
   },
   "devDependencies": {

--- a/packages/sonda/src/report/processors/outputs.ts
+++ b/packages/sonda/src/report/processors/outputs.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 import { readFileSync } from 'fs';
 import { loadCodeAndMap } from 'load-source-map';
-import { default as remapping, type DecodedSourceMap, type EncodedSourceMap } from '@ampproject/remapping';
+import { default as remapping, type DecodedSourceMap, type EncodedSourceMap } from '@jridgewell/remapping';
 import { Report } from '../report.js';
 import { Config } from '../../config.js';
 import { getBytesPerSource, getSizes } from './sourcemap.js';

--- a/packages/sonda/src/report/processors/sourcemap.ts
+++ b/packages/sonda/src/report/processors/sourcemap.ts
@@ -1,5 +1,5 @@
 import { gzipSync, brotliCompressSync } from 'zlib';
-import type { DecodedSourceMap, SourceMapSegment } from '@ampproject/remapping';
+import type { DecodedSourceMap, SourceMapSegment } from '@jridgewell/remapping';
 import type { Config } from '../../config.js';
 import type { Sizes } from '../types.js';
 

--- a/packages/sonda/src/report/types.ts
+++ b/packages/sonda/src/report/types.ts
@@ -1,4 +1,4 @@
-import type { DecodedSourceMap } from '@ampproject/remapping';
+import type { DecodedSourceMap } from '@jridgewell/remapping';
 import type { Integration } from '../config.js';
 
 export interface JsonReport {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,9 @@ importers:
 
   packages/sonda:
     dependencies:
-      '@ampproject/remapping':
+      '@jridgewell/remapping':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.5
       open:
         specifier: ^10.2.0
         version: 10.2.0
@@ -2559,6 +2559,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -11097,7 +11100,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2001.5(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2001.5(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.99.9))(webpack@5.99.9(esbuild@0.25.5))
+      '@angular-devkit/build-webpack': 0.2001.5(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.99.9))(webpack@5.99.9)
       '@angular-devkit/core': 20.1.5(chokidar@4.0.3)
       '@angular/build': 20.1.5(14179ababef926ce1a0b033e191fac79)
       '@angular/compiler-cli': 20.1.6(@angular/compiler@20.1.6)(typescript@5.9.2)
@@ -11111,13 +11114,13 @@ snapshots:
       '@babel/preset-env': 7.27.2(@babel/core@7.27.7)
       '@babel/runtime': 7.27.6
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.1.5(@angular/compiler-cli@20.1.6(@angular/compiler@20.1.6)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.99.9(esbuild@0.25.5))
+      '@ngtools/webpack': 20.1.5(@angular/compiler-cli@20.1.6(@angular/compiler@20.1.6)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.99.9)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.27.7)(webpack@5.99.9(esbuild@0.25.5))
+      babel-loader: 10.0.0(@babel/core@7.27.7)(webpack@5.99.9)
       browserslist: 4.25.2
-      copy-webpack-plugin: 13.0.0(webpack@5.99.9(esbuild@0.25.5))
-      css-loader: 7.1.2(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.99.9(esbuild@0.25.5))
+      copy-webpack-plugin: 13.0.0(webpack@5.99.9)
+      css-loader: 7.1.2(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.99.9)
       esbuild-wasm: 0.25.5
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -11125,22 +11128,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.3.0
-      less-loader: 12.3.0(@rspack/core@1.4.11(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.9(esbuild@0.25.5))
-      license-webpack-plugin: 4.0.2(webpack@5.99.9(esbuild@0.25.5))
+      less-loader: 12.3.0(@rspack/core@1.4.11(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.9)
+      license-webpack-plugin: 4.0.2(webpack@5.99.9)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.2(webpack@5.99.9(esbuild@0.25.5))
+      mini-css-extract-plugin: 2.9.2(webpack@5.99.9)
       open: 10.1.2
       ora: 8.2.0
       picomatch: 4.0.2
       piscina: 5.1.2
       postcss: 8.5.6
-      postcss-loader: 8.1.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.9.2)(webpack@5.99.9(esbuild@0.25.5))
+      postcss-loader: 8.1.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.9.2)(webpack@5.99.9)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.89.2
-      sass-loader: 16.0.5(@rspack/core@1.4.11(@swc/helpers@0.5.17))(sass@1.89.2)(webpack@5.99.9(esbuild@0.25.5))
+      sass-loader: 16.0.5(@rspack/core@1.4.11(@swc/helpers@0.5.17))(sass@1.89.2)(webpack@5.99.9)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.99.9(esbuild@0.25.5))
+      source-map-loader: 5.0.0(webpack@5.99.9)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -11150,7 +11153,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.99.9)
       webpack-dev-server: 5.2.2(webpack@5.99.9)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.99.9(esbuild@0.25.5))
+      webpack-subresource-integrity: 5.1.0(webpack@5.99.9)
     optionalDependencies:
       '@angular/core': 20.1.6(@angular/compiler@20.1.6)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.1.6(@angular/animations@20.1.6(@angular/common@20.1.6(@angular/core@20.1.6(@angular/compiler@20.1.6)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.1.6(@angular/compiler@20.1.6)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.1.6(@angular/core@20.1.6(@angular/compiler@20.1.6)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.1.6(@angular/compiler@20.1.6)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -11182,7 +11185,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2001.5(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.99.9))(webpack@5.99.9(esbuild@0.25.5))':
+  '@angular-devkit/build-webpack@0.2001.5(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.99.9))(webpack@5.99.9)':
     dependencies:
       '@angular-devkit/architect': 0.2001.5(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -13607,6 +13610,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.4
       '@jridgewell/trace-mapping': 0.3.29
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.10':
@@ -14015,7 +14023,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.4.6':
     optional: true
 
-  '@ngtools/webpack@20.1.5(@angular/compiler-cli@20.1.6(@angular/compiler@20.1.6)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.99.9(esbuild@0.25.5))':
+  '@ngtools/webpack@20.1.5(@angular/compiler-cli@20.1.6(@angular/compiler@20.1.6)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.99.9)':
     dependencies:
       '@angular/compiler-cli': 20.1.6(@angular/compiler@20.1.6)(typescript@5.9.2)
       typescript: 5.9.2
@@ -16415,7 +16423,7 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-loader@10.0.0(@babel/core@7.27.7)(webpack@5.99.9(esbuild@0.25.5)):
+  babel-loader@10.0.0(@babel/core@7.27.7)(webpack@5.99.9):
     dependencies:
       '@babel/core': 7.27.7
       find-up: 5.0.0
@@ -16985,7 +16993,7 @@ snapshots:
       graceful-fs: 4.2.11
       p-event: 6.0.1
 
-  copy-webpack-plugin@13.0.0(webpack@5.99.9(esbuild@0.25.5)):
+  copy-webpack-plugin@13.0.0(webpack@5.99.9):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -17073,7 +17081,7 @@ snapshots:
       '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
       webpack: 5.101.0(webpack-cli@6.0.1)
 
-  css-loader@7.1.2(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.99.9(esbuild@0.25.5)):
+  css-loader@7.1.2(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.99.9):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -18996,7 +19004,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(@rspack/core@1.4.11(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.9(esbuild@0.25.5)):
+  less-loader@12.3.0(@rspack/core@1.4.11(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.9):
     dependencies:
       less: 4.3.0
     optionalDependencies:
@@ -19017,7 +19025,7 @@ snapshots:
       needle: 3.3.1
       source-map: 0.6.1
 
-  license-webpack-plugin@4.0.2(webpack@5.99.9(esbuild@0.25.5)):
+  license-webpack-plugin@4.0.2(webpack@5.99.9):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -19772,7 +19780,7 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.99.9(esbuild@0.25.5)):
+  mini-css-extract-plugin@2.9.2(webpack@5.99.9):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.2
@@ -20804,7 +20812,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  postcss-loader@8.1.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.9.2)(webpack@5.99.9(esbuild@0.25.5)):
+  postcss-loader@8.1.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.9.2)(webpack@5.99.9):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.2)
       jiti: 1.21.7
@@ -21698,7 +21706,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(@rspack/core@1.4.11(@swc/helpers@0.5.17))(sass@1.89.2)(webpack@5.99.9(esbuild@0.25.5)):
+  sass-loader@16.0.5(@rspack/core@1.4.11(@swc/helpers@0.5.17))(sass@1.89.2)(webpack@5.99.9):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -22061,7 +22069,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.99.9(esbuild@0.25.5)):
+  source-map-loader@5.0.0(webpack@5.99.9):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -23267,7 +23275,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.99.9(esbuild@0.25.5)):
+  webpack-subresource-integrity@5.1.0(webpack@5.99.9):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.99.9(esbuild@0.25.5)


### PR DESCRIPTION
Even though [`@ampproject/remapping`](https://npm.im/@ampproject/remapping) isn't deprecated on npm (yet), it's [repo](https://github.com/ampproject/remapping) is archived, so people should move to [`@jridgewell/remapping`](https://npm.im/@jridgewell/remapping)

> Development moved to [monorepo](https://github.com/jridgewell/sourcemaps)
> See https://github.com/jridgewell/sourcemaps/tree/main/packages/remapping for latest code.

---

I'm sure people from the wider @e18e ecosystem cleanup (like @43081j, @benmccann, @Fuzzyma, @outslept & @talentlessguy) will be very happy to see these kind of changes as well