### PR TITLE
chore(sonda): add package bugs metadata

### DIFF
--- a/.changeset/loud-masks-push.md
+++ b/.changeset/loud-masks-push.md
@@ -1,0 +1,5 @@
+---
+"sonda": patch
+---
+
+chore(sonda): add package bugs metadata

--- a/packages/sonda/package.json
+++ b/packages/sonda/package.json
@@ -27,6 +27,9 @@
 		"url": "git+https://github.com/filipsobol/sonda.git",
 		"directory": "packages/sonda"
 	},
+	"bugs": {
+		"url": "https://github.com/filipsobol/sonda/issues"
+	},
 	"bin": {
 		"sonda-angular": "./bin/sonda-angular.js"
 	},


### PR DESCRIPTION
## Summary

- add `bugs` metadata for the repository issue tracker
- add a patch changeset so the metadata can be published in a future release

## Verification

- `node -e "const p=require('./packages/sonda/package.json'); if (p.bugs?.url !== 'https://github.com/filipsobol/sonda/issues') process.exit(1); console.log(JSON.stringify({name:p.name, version:p.version, repository:p.repository, bugs:p.bugs, homepage:p.homepage, license:p.license}, null, 2))"`
- `npm pack ./packages/sonda --dry-run --ignore-scripts --json`
- `npx --yes pnpm@11.5.2 --filter sonda build`
- `npx --yes pnpm@11.5.2 --filter sonda test`
- `git diff --check`

This is an AI-assisted package metadata cleanup.
