### PR TITLE
chore: add npm bugs metadata to package.json

### DIFF
--- a/packages/sonda/package.json
+++ b/packages/sonda/package.json
@@ -135,4 +135,8 @@
 			"versions": "^1.0.0"
 		}
 	}
+,
+	"bugs": {
+		"url": "https://github.com/filipsobol/sonda/issues"
+	}
 }


### PR DESCRIPTION
The published `sonda` package exposes `repository` and `homepage` metadata but no `bugs` field. This adds `bugs.url` pointing to the GitHub issue tracker.

No runtime code, dependencies, tests, or build configuration are changed.