### PR TITLE
docs: add bugs metadata for sonda

### DIFF
--- a/packages/sonda/package.json
+++ b/packages/sonda/package.json
@@ -21,6 +21,9 @@
 		"withastro"
 	],
 	"homepage": "https://sonda.dev",
+	"bugs": {
+		"url": "https://github.com/filipsobol/sonda/issues"
+	},
 	"license": "MIT",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This PR adds the missing `bugs` metadata to the `sonda` package, as requested in the microbounty issue #1515.

- Added `bugs` URL pointing to the repository issues.

Fixes #1515