### PR TITLE
Fix documented default for open option

### DIFF
--- a/.changeset/curvy-hounds-open.md
+++ b/.changeset/curvy-hounds-open.md
@@ -1,0 +1,5 @@
+---
+"sonda": patch
+---
+
+Correct the documented default value for the `open` option.

--- a/packages/sonda/src/config.ts
+++ b/packages/sonda/src/config.ts
@@ -176,7 +176,7 @@ export interface UserOptions {
 	 * the given file extension (`.html` or `.json`, depending on the `format` option)
 	 * after the build process.
 	 *
-	 * @default false
+	 * @default true
 	 */
 	open?: boolean | Format;
 


### PR DESCRIPTION
## Summary

- Correct the documented default for `open` from `false` to `true`
- Add a patch changeset

Fixes #335

## Validation

- `git diff --check`